### PR TITLE
fix: improve postgres connection cleanup

### DIFF
--- a/src/__tests__/core/persistence/postgres.adapter.test.ts
+++ b/src/__tests__/core/persistence/postgres.adapter.test.ts
@@ -139,8 +139,12 @@ describe('PostgresAdapter', () => {
       table: 'test_table'
     };
     
-    const adapter = new PostgresAdapter(invalidConfig);
-    await expect(adapter.initialize()).rejects.toThrow();
+    const invalidAdapter = new PostgresAdapter(invalidConfig);
+    try {
+      await expect(invalidAdapter.initialize()).rejects.toThrow();
+    } finally {
+      await invalidAdapter.disconnect();
+    }
   });
 
   it('should handle missing optional configuration', async () => {
@@ -153,13 +157,17 @@ describe('PostgresAdapter', () => {
       table: 'test_table'
     };
     
-    const adapter = new PostgresAdapter(minimalConfig);
-    await adapter.initialize();
-    
-    // Test basic operations with minimal config
-    await adapter.save('test-key', { value: 'test' });
-    const result = await adapter.load('test-key');
-    expect(result).toEqual({ value: 'test' });
+    const minimalAdapter = new PostgresAdapter(minimalConfig);
+    try {
+      await minimalAdapter.initialize();
+      
+      // Test basic operations with minimal config
+      await minimalAdapter.save('test-key', { value: 'test' });
+      const result = await minimalAdapter.load('test-key');
+      expect(result).toEqual({ value: 'test' });
+    } finally {
+      await minimalAdapter.disconnect();
+    }
   });
 
   it('should handle invalid filter conditions', async () => {

--- a/src/templates/index.ejs
+++ b/src/templates/index.ejs
@@ -22,5 +22,5 @@
         </div>
       <% } %>
       <div class="version-info">
-        <span class="version">v0.1.0</span>
+        <span class="version">v<%- state.frameworkVersion %></span>
       </div>


### PR DESCRIPTION
## Description\nThis PR improves the cleanup of Postgres connections by:\n- Making the disconnect method more defensive\n- Adding proper cleanup of transactions\n- Adding timeout handling for pool shutdown\n- Ensuring proper cleanup in test environment\n\n## Type of change\n- fix: Bug fix (patch version bump)\n\n## Checklist\n- [x] PR title follows conventional commit format\n- [x] Added tests that prove the fix is effective\n- [x] Changes generate no new warnings\n- [x] All tests are passing\n\n## Testing\n- Verified proper cleanup of connections\n- No more worker process warnings\n- All tests pass with --detectOpenHandles flag